### PR TITLE
Use `terraform-yaml-config` module in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Check out these related projects.
 - [terraform-aws-iam-role](https://github.com/cloudposse/terraform-aws-iam-role) - A Terraform module that creates IAM role with provided JSON IAM polices documents.
 - [terraform-aws-iam-policy-document-aggregator](https://github.com/cloudposse/terraform-aws-iam-policy-document-aggregator) - Terraform module to aggregate multiple IAM policy documents into single policy document
 - [terraform-aws-iam-chamber-s3-role](https://github.com/cloudposse/terraform-aws-iam-chamber-s3-role) - Terraform module to provision an IAM role with configurable permissions to access S3 as chamber backend.
+- [terraform-yaml-config](https://github.com/cloudposse/terraform-yaml-config) - Terraform module to convert local and remote YAML configuration templates into Terraform lists and maps.
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -100,14 +100,13 @@ usage: |-
 
 
   ```hcl
-    locals {
-      service_control_policy_statements = flatten(
-        [
-          for file in fileset(path.module, "policies/*.yaml") : [
-            for k, v in yamldecode(file(format("%s/%s", path.module, file))) : v
-          ]
-        ]
-      )
+    module "yaml_config" {
+      source = "git::https://github.com/cloudposse/terraform-yaml-config.git?ref=master"
+
+      list_config_local_base_path = path.module
+      list_config_paths           = ["policies/*.yaml"]
+
+      context = module.this.context
     }
 
     data "aws_caller_identity" "this" {}
@@ -115,8 +114,9 @@ usage: |-
     module "service_control_policies" {
       source = "../../"
 
-      service_control_policy_statements = local.service_control_policy_statements
-      target_id                         = data.aws_caller_identity.this.account_id
+      service_control_policy_statements  = module.yaml_config.list_configs
+      service_control_policy_description = var.service_control_policy_description
+      target_id                          = data.aws_caller_identity.this.account_id
 
       context = module.this.context
     }

--- a/README.yaml
+++ b/README.yaml
@@ -56,6 +56,9 @@ related:
   - name: "terraform-aws-iam-chamber-s3-role"
     description: "Terraform module to provision an IAM role with configurable permissions to access S3 as chamber backend."
     url: "https://github.com/cloudposse/terraform-aws-iam-chamber-s3-role"
+  - name: "terraform-yaml-config"
+    description: "Terraform module to convert local and remote YAML configuration templates into Terraform lists and maps."
+    url: "https://github.com/cloudposse/terraform-yaml-config"
 
 # List any resources helpful for someone to get started. For example, link to the hashicorp documentation or AWS documentation.
 references:

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,11 +1,10 @@
-locals {
-  service_control_policy_statements = flatten(
-    [
-      for file in fileset(path.module, "policies/*.yaml") : [
-        for k, v in yamldecode(file(format("%s/%s", path.module, file))) : v
-      ]
-    ]
-  )
+module "yaml_config" {
+  source = "git::https://github.com/cloudposse/terraform-yaml-config.git?ref=tags/0.1.0"
+
+  list_config_local_base_path = path.module
+  list_config_paths           = ["policies/*.yaml"]
+
+  context = module.this.context
 }
 
 data "aws_caller_identity" "this" {}
@@ -13,7 +12,7 @@ data "aws_caller_identity" "this" {}
 module "service_control_policies" {
   source = "../../"
 
-  service_control_policy_statements  = local.service_control_policy_statements
+  service_control_policy_statements  = module.yaml_config.list_configs
   service_control_policy_description = var.service_control_policy_description
   target_id                          = data.aws_caller_identity.this.account_id
 


### PR DESCRIPTION
## what
* Use [terraform-yaml-config](https://github.com/cloudposse/terraform-yaml-config) module in the example

## why
* Simplify the logic to convert YAML configs into Terraform lists and maps (the complex conversion logic is in one place now in the `terraform-yaml-config` module) 
* [terraform-yaml-config](https://github.com/cloudposse/terraform-yaml-config) is a Terraform module to convert local and remote YAML configuration templates into Terraform lists and maps.
*  The module accepts paths to local and remote YAML configuration template files and converts the templates into Terraform lists and maps for consumption in other Terraform modules.
* The module also accepts a map of parameters for interpolation within the YAML config templates.

