### PR TITLE
add policy to deny non-nitro instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ Available targets:
 |------|---------|
 | aws | >= 3.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_organizations_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) |
+| [aws_organizations_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -199,7 +213,6 @@ Available targets:
 |------|-------------|
 | organizations\_policy\_arn | Amazon Resource Name (ARN) of the policy |
 | organizations\_policy\_id | The unique identifier of the policy |
-
 <!-- markdownlint-restore -->
 
 

--- a/catalog/ec2-policies.yaml
+++ b/catalog/ec2-policies.yaml
@@ -1,0 +1,81 @@
+#
+# This policy denies instance types that aren't based on the Nitro system as documented in the following document:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
+#
+- sid: "DenyNonNitroInstances"
+  effect: "Deny"
+  actions:
+    - "ec2:RunInstances"
+  condition:
+    - test: "StringNotLike"
+      variable: "ec2:InstanceType"
+      values:
+        - a1
+        - a1.metal
+        - c5
+        - c5.metal
+        - c5a
+        - c5ad
+        - c5d
+        - c5d.metal
+        - c5n
+        - c5n.metal
+        - c6g
+        - c6g.metal
+        - c6gd
+        - c6gd.metal
+        - c6gn
+        - d3
+        - d3en
+        - g4
+        - i3.metal
+        - i3en
+        - i3en.metal
+        - inf1
+        - m5
+        - m5.metal
+        - m5a
+        - m5ad
+        - m5d
+        - m5d.metal
+        - m5dn
+        - m5dn.metal
+        - m5n
+        - m5n.metal
+        - m5zn
+        - m5zn.metal
+        - m6g
+        - m6g.metal
+        - m6gd
+        - m6gd.metal
+        - mac1.metal
+        - p3dn.24xlarge
+        - p4
+        - r5
+        - r5.metal
+        - r5a
+        - r5ad
+        - r5b
+        - r5b.metal
+        - r5d
+        - r5d.metal
+        - r5dn
+        - r5dn.metal
+        - r5n
+        - r5n.metal
+        - r6g
+        - r6g.metal
+        - r6gd
+        - r6gd.metal
+        - t3
+        - t3a
+        - t4g
+        - u-12tb1.metal
+        - u-18tb1.metal
+        - u-24tb1.metal
+        - u-6tb1.metal
+        - u-9tb1.metal
+        - z1d
+        - z1d.metal
+  resources:
+    - "arn:aws:ec2:*:*:instance/*"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -13,6 +13,20 @@
 |------|---------|
 | aws | >= 3.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_organizations_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) |
+| [aws_organizations_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -42,5 +56,4 @@
 |------|-------------|
 | organizations\_policy\_arn | Amazon Resource Name (ARN) of the policy |
 | organizations\_policy\_id | The unique identifier of the policy |
-
 <!-- markdownlint-restore -->


### PR DESCRIPTION
## what
* Add a policy to deny instances that are not based on the [Nitro system](https://aws.amazon.com/ec2/nitro/)

## why
* AWS Nitro provides a number of enhanced feature, including automatic instance-to-instance encryption

## references
* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
