### PR TITLE
Fix: resource attributes that cannot be determined

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "this" {
 }
 
 resource "aws_organizations_policy" "this" {
-  count       = module.this.enabled && length(local.statements) > 0 ? 1 : 0
+  count       = module.this.enabled && length(var.service_control_policy_statements) > 0 ? 1 : 0
   name        = module.this.id
   description = var.service_control_policy_description
   content     = local.service_control_policy_json
@@ -43,7 +43,7 @@ resource "aws_organizations_policy" "this" {
 }
 
 resource "aws_organizations_policy_attachment" "this" {
-  count     = module.this.enabled && length(local.statements) > 0 ? 1 : 0
+  count     = module.this.enabled && length(var.service_control_policy_statements) > 0 ? 1 : 0
   policy_id = join("", aws_organizations_policy.this.*.id)
   target_id = var.target_id
 }


### PR DESCRIPTION
## what
* This checks the input variable instead of `local.statements`, which previously required creating the policy documents to determine.

## why
* The previous PR https://github.com/cloudposse/terraform-aws-service-control-policies/pull/15 worked for account SCPs but did not work for org SCPs. I checked this locally for all 3 types of policies (ou, org, and account) in `components/terraform/account`.

## references
N/A

