### PR TITLE
Ensure support of the AWS Provider V5 and latest terraform

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,6 +10,7 @@ on:
       - 'docs/**'
       - 'examples/**'
       - 'test/**'
+      - 'README.*'
 
 permissions:
   contents: write

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   terraform-module:
-    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release.yml@main
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,6 @@
 module "yaml_config" {
   source  = "cloudposse/config/yaml"
-  version = "0.7.0"
+  version = "1.0.2"
 
   list_config_local_base_path = path.module
   list_config_paths           = var.list_config_paths

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,6 @@ resource "aws_organizations_policy" "this" {
 
 resource "aws_organizations_policy_attachment" "this" {
   count     = module.this.enabled && length(var.service_control_policy_statements) > 0 ? 1 : 0
-  policy_id = join("", aws_organizations_policy.this.*.id)
+  policy_id = join("", aws_organizations_policy.this[*].id)
   target_id = var.target_id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "organizations_policy_id" {
-  value       = join("", aws_organizations_policy.this.*.id)
+  value       = join("", aws_organizations_policy.this[*].id)
   description = "The unique identifier of the policy"
 }
 
 output "organizations_policy_arn" {
-  value       = join("", aws_organizations_policy.this.*.arn)
+  value       = join("", aws_organizations_policy.this[*].arn)
   description = "Amazon Resource Name (ARN) of the policy"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

Ensure support of the AWS Provider V5
Update terraform version
Update dependencies in tests
Linter fixes

## why

Maintenance

## references

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0
