### PR TITLE
Minor cleanups

### DIFF
--- a/catalog/lambda-policies.yaml
+++ b/catalog/lambda-policies.yaml
@@ -4,9 +4,9 @@
     - "lambda:CreateFunction"
     - "lambda:UpdateFunctionConfiguration"
   condition:
-    - test: "Bool"
+    - test: "Null"
       variable: "lambda:VpcIds"
       values:
-        - false
+        - true
   resources:
     - "*"

--- a/catalog/rds-policies.yaml
+++ b/catalog/rds-policies.yaml
@@ -5,7 +5,7 @@
     - "rds:CreateDBInstance"
     - "rds:RestoreDBClusterFromS3"
     - "rds:RestoreDBInstanceFromS3"
-    - "rds:RestoreDBClusterFromDBSnapshot"
+    - "rds:RestoreDBClusterFromSnapshot"
     - "rds:RestoreDBClusterToPointInTime"
   condition:
     - test: "Bool"

--- a/catalog/region-restriction-templates/DenyRegions.yaml
+++ b/catalog/region-restriction-templates/DenyRegions.yaml
@@ -40,6 +40,7 @@
     - "shield:*"
     - "sts:*"
     - "support:*"
+    - "supportplans:*"
     - "trustedadvisor:*"
     - "waf-regional:*"
     - "waf:*"

--- a/catalog/region-restriction-templates/DenyRegions.yaml
+++ b/catalog/region-restriction-templates/DenyRegions.yaml
@@ -6,11 +6,12 @@
   effect: "Deny"
   not_actions:
     - "a4b:*"
+    - "account:*"
     - "acm:*"
+    - "artifact:*"
     - "aws-marketplace-management:*"
     - "aws-marketplace:*"
     - "aws-portal:*"
-    - "awsbillingconsole:*"
     - "budgets:*"
     - "ce:*"
     - "chime:*"

--- a/catalog/region-restriction-templates/RestrictToSpecifiedRegions.yaml
+++ b/catalog/region-restriction-templates/RestrictToSpecifiedRegions.yaml
@@ -40,6 +40,7 @@
     - "shield:*"
     - "sts:*"
     - "support:*"
+    - "supportplans:*"
     - "trustedadvisor:*"
     - "waf-regional:*"
     - "waf:*"

--- a/catalog/region-restriction-templates/RestrictToSpecifiedRegions.yaml
+++ b/catalog/region-restriction-templates/RestrictToSpecifiedRegions.yaml
@@ -6,11 +6,12 @@
   effect: "Deny"
   not_actions:
     - "a4b:*"
+    - "account:*"
     - "acm:*"
+    - "artifact:*"
     - "aws-marketplace-management:*"
     - "aws-marketplace:*"
     - "aws-portal:*"
-    - "awsbillingconsole:*"
     - "budgets:*"
     - "ce:*"
     - "chime:*"

--- a/catalog/s3-policies.yaml
+++ b/catalog/s3-policies.yaml
@@ -11,7 +11,6 @@
   effect: "Deny"
   actions:
     - "s3:PutBucketPublicAccessBlock"
-    - "s3:DeletePublicAccessBlock"
   resources:
     - "*"
 

--- a/catalog/s3-templates/DenyS3InNonSelectedRegion.yaml
+++ b/catalog/s3-templates/DenyS3InNonSelectedRegion.yaml
@@ -1,9 +1,10 @@
 # Requires parameter:
 #  - s3_regions_lockdown # Comma separated list of regions or region patterns in which to allow S3 bucket creation
 #
-# NOTE: "us-east-1" is the default region and cannot be specified explicitly.
-#       Therefore, this policy always excludes "us-east-1" from the list of allowed regions,
-#       because for us-east-1, s3:LocationConstraint is empty.
+# NOTE: "us-east-1" is the default region, and is indicated by `s3:LocationConstraint`
+#       being null. We allow "us-east-1" as a value because it is easier and does not
+#       hurt, but it is not effective. We have to test for the presence of the value
+#       (or lack thereof) to manage that region, which we do with a separate test.
 
 - sid: "DenyS3InNonSelectedRegion"
   effect: "Deny"
@@ -17,5 +18,14 @@
       %{ for r in split(",", s3_regions_lockdown) }
         - ${trimspace(r)}
       %{ endfor }
+    # Separate test for us-east-1, which is the default region
+    %{ if contains(split(",", s3_regions_lockdown), "us-east-1") }
+    - test: "Null"
+      variable: "s3:LocationConstraint"
+      # The regions where the creation of buckets will be allowed
+      values:
+        - false
+    %{ endif }
+
   resources:
     - "arn:aws:s3:::*"


### PR DESCRIPTION
## what

Minor fixes to several SCPs

- `DenyLambdaWithoutVpc` was previously invalid. It is now valid, but has not been thoroughly tested to ensure it does what it promises.
- `DenyRDSUnencrypted` was fixed to deny `rds:RestoreDBClusterFromSnapshot` when not encrypted. Previously this action was not denied, and instead the nonexistent `RestoreDBClusterFromDBSnapshot` was denied
- The `DenyS3BucketsPublicAccess` policy was cleaned up by eliminating the nonexistent `s3:DeletePublicAccessBlock` action. Note that it still is probably not something you want to use, because it denies enabling a public access block as well as removing one. We hope to have a better policy in the future.
- The Region Restriction Templates `DenyRegions` and `RestrictToSpecifiedRegions` were updated to exclude the `account`, `artifact`, and `supportplans` services from region restrictions, since they are global services. The obsolete `awsbillingconsole` service was removed.
- `DenyS3InNonSelectedRegion` was fixed to allow users to allow S3 bucket creation in `us-east-1`. Previously `us-east-1` was always prohibited even when expressly allowed, due to quirks in S3.

## why

- Restore intended behavior

## references

- Closes #33 
