### PR TITLE
Use `minified_json` to reduce scp policy character count

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.49"
     }
     local = {
       source  = "hashicorp/local"

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,5 @@
 locals {
   service_control_policy_statements_map = { for i in var.service_control_policy_statements : i.sid => i }
-
-  statements = flatten([for i in data.aws_iam_policy_document.this : jsondecode(i.json).Statement])
-  version    = try(jsondecode(values(data.aws_iam_policy_document.this)[0].json).Version, null)
-
-  service_control_policy_json = jsonencode(
-    {
-      Version   = local.version
-      Statement = local.statements
-    }
-  )
 }
 
 data "aws_iam_policy_document" "this" {
@@ -38,7 +28,7 @@ resource "aws_organizations_policy" "this" {
   count       = module.this.enabled && length(var.service_control_policy_statements) > 0 ? 1 : 0
   name        = module.this.id
   description = var.service_control_policy_description
-  content     = local.service_control_policy_json
+  content     = data.aws_iam_policy_document.this.minified_json
   tags        = module.this.tags
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 5.49"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
- Use `minified_json` to reduce scp policy character count

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->
- AWS terraform provider released a new version of their data source which includes a minified_json attribute
- This simplifies the code and keeps the length of the policy as short as possible

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.49.0
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#minified_json
