### PR TITLE
Update EC2 policies to include new instance types

### DIFF
--- a/catalog/ec2-policies.yaml
+++ b/catalog/ec2-policies.yaml
@@ -13,14 +13,17 @@
 
 # This policy denies instance families that aren't based on the Nitro system as documented in the following document:
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances
-# The listing below *are* Nitro-based instances. Most are collected from the following CLI query:
-#     aws ec2 describe-instance-types \
-#        --filters Name=hypervisor,Values=nitro \
-#        --query "InstanceTypes[*].[InstanceType]" --output text | cut -f 1 -d. | sort | uniq
+# The listing below *are* Nitro-based instances. They are collected from the following CLI query:
 #
-# However, that the command only lists instance types available in the default region. To be
+#      aws --region us-east-1 ec2 describe-instance-types \
+#        --filters Name=hypervisor,Values=nitro \
+#        --query "InstanceTypes[*].[InstanceType]" --output text | \
+#          cut -f 1 -d. | sort | uniq | awk '{print "        - " $0 ".*"}'
+#
+# However, that the command only lists instance types available in the specified region. To be
 # fully comprehensive, the command should be run in all regions where instances are launched.
-# As a shortcut, we only run the command in us-east-1, us-west-2, and eu-north-1, as these
+# As a shortcut, we only run the command in the default regions (those that do not require opt-in).
+# To date, it appears that the combination of us-east-1, us-east-2, us-west-2, and eu-west-1
 # regions combined appear to cover all instance types.
 #
 # In order to fit within the 5120-character limit for policies
@@ -37,7 +40,7 @@
     - test: "StringNotLike"
       variable: "ec2:InstanceType"
       values:
-        # updated 2024-04-11
+        # updated 2025-02-14
         - a1.*
         - c5.*
         - c5a.*
@@ -55,16 +58,20 @@
         - c7g.*
         - c7gd.*
         - c7gn.*
+        - c7i-flex.*
         - c7i.*
+        - c8g.*
         - d3.*
         - d3en.*
         - dl1.*
         - dl2q.*
+        - f2.*
         - g4ad.*
         - g4dn.*
         - g5.*
         - g5g.*
         - g6.*
+        - g6e.*
         - gr6.*
         - hpc6a.*
         - hpc6id.*
@@ -73,6 +80,8 @@
         - i3en.*
         - i4g.*
         - i4i.*
+        - i7ie.*
+        - i8g.*
         - im4gn.*
         - inf1.*
         - inf2.*
@@ -94,11 +103,14 @@
         - m7a.*
         - m7g.*
         - m7gd.*
-        - m7i.*
         - m7i-flex.*
+        - m7i.*
+        - m8g.*
         - p3dn.*
         - p4d.*
         - p5.*
+        - p5e.*
+        - p5en.*
         - r5.*
         - r5a.*
         - r5ad.*
@@ -118,22 +130,31 @@
         - r7gd.*
         - r7i.*
         - r7iz.*
+        - r8g.*
         - t3.*
         - t3a.*
         - t4g.*
         - trn1.*
         - trn1n.*
+        - trn2.*
         - u-12tb1.*
         - u-18tb1.*
         - u-24tb1.*
         - u-3tb1.*
         - u-6tb1.*
         - u-9tb1.*
+        - u7i-12tb.*
+        - u7i-6tb.*
+        - u7i-8tb.*
+        - u7in-16tb.*
+        - u7in-24tb.*
+        - u7in-32tb.*
         - vt1.*
         - x2gd.*
         - x2idn.*
         - x2iedn.*
         - x2iezn.*
+        - x8g.*
         - z1d.*
 
   resources:
@@ -144,13 +165,16 @@
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/data-protection.html#encryption-transit
 # and enumerated by the following command (adapted from the command specified in the documentation):
 #
-#  aws ec2 describe-instance-types \
-#  --filters Name=network-info.encryption-in-transit-supported,Values=true \
-#  --query "InstanceTypes[*].[InstanceType]" --output text | cut -f 1 -d. | sort | uniq
+#      aws --region us-east-1 ec2 describe-instance-types \
+#        --filters Name=network-info.encryption-in-transit-supported,Values=true \
+#        --query "InstanceTypes[*].[InstanceType]" --output text | \
+#          cut -f 1 -d. | sort | uniq | awk '{print "        - " $0 ".*"}'
 #
-# Note that the command only lists instance types available in the default region. To be
+# However, that the command only lists instance types available in the specified region. To be
 # fully comprehensive, the command should be run in all regions where instances are launched.
-# Since that is difficult, this policy is based on the official AWS documentation instead.
+# As a shortcut, we only run the command in the default regions (those that do not require opt-in).
+# To date, it appears that the combination of us-east-1, us-east-2, us-west-2, and eu-west-1
+# regions combined appear to cover all instance types.
 #
 # In order to fit within the 5120-character limit for policies
 # (See https://docs.aws.amazon.com/organizations/latest/userguide/org_troubleshoot_policies.html )
@@ -166,7 +190,7 @@
     - test: "StringNotLike"
       variable: "ec2:InstanceType"
       values:
-        # updated 2024-04-11
+        # updated 2025-02-14
         - c5a.*
         - c5ad.*
         - c5n.*
@@ -179,15 +203,19 @@
         - c7g.*
         - c7gd.*
         - c7gn.*
+        - c7i-flex.*
         - c7i.*
+        - c8g.*
         - d3.*
         - d3en.*
         - dl1.*
         - dl2q.*
+        - f2.*
         - g4ad.*
         - g4dn.*
         - g5.*
         - g6.*
+        - g6e.*
         - gr6.*
         - hpc6a.*
         - hpc6id.*
@@ -196,6 +224,8 @@
         - i3en.*
         - i4g.*
         - i4i.*
+        - i7ie.*
+        - i8g.*
         - im4gn.*
         - inf1.*
         - inf2.*
@@ -211,12 +241,14 @@
         - m7a.*
         - m7g.*
         - m7gd.*
-        - m7i.*
         - m7i-flex.*
+        - m7i.*
+        - m8g.*
         - p3dn.*
         - p4d.*
-        - p4de.*
         - p5.*
+        - p5e.*
+        - p5en.*
         - r5dn.*
         - r5n.*
         - r6a.*
@@ -229,18 +261,27 @@
         - r7gd.*
         - r7i.*
         - r7iz.*
+        - r8g.*
         - trn1.*
         - trn1n.*
+        - trn2.*
         - u-12tb1.*
         - u-18tb1.*
         - u-24tb1.*
         - u-3tb1.*
         - u-6tb1.*
         - u-9tb1.*
+        - u7i-12tb.*
+        - u7i-6tb.*
+        - u7i-8tb.*
+        - u7in-16tb.*
+        - u7in-24tb.*
+        - u7in-32tb.*
         - vt1.*
         - x2idn.*
         - x2iedn.*
         - x2iezn.*
+        - x8g.*
 
   resources:
     - "arn:aws:ec2:*:*:instance/*"


### PR DESCRIPTION
## what

- Update `DenyEC2NonNitroInstances` and `DenyEC2InstancesWithoutEncryptionInTransit` to include instances made available since the last update

## why

- Allow qualifying instances that would have otherwise been denied because they were too new
