### PR TITLE
Allow Lambda in ue-east-1 required for cloudfront lambda on edge

### DIFF
--- a/catalog/region-restriction-templates/RestrictToSpecifiedRegions.yaml
+++ b/catalog/region-restriction-templates/RestrictToSpecifiedRegions.yaml
@@ -28,6 +28,7 @@
     - "iam:*"
     - "importexport:*"
     - "kms:*"
+    - "lambda:*"
     - "mobileanalytics:*"
     - "networkmanager:*"
     - "organizations:*"


### PR DESCRIPTION
## what
* Allow Lambda in ue-east-1

## why
*  Required for cloudfront lambda on edge

## references
* https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/330
