### PR TITLE
Create identity-center-policies.yaml

### DIFF
--- a/catalog/identity-center-policies.yaml
+++ b/catalog/identity-center-policies.yaml
@@ -1,0 +1,6 @@
+- sid: "DenyCreatingAccountIdcInstances"
+  effect: "Deny"
+  actions:
+    - "sso:CreateInstance"
+  resources:
+    - "*"


### PR DESCRIPTION
What: A policy to deny adding a new AWS IAM Identity Center instance on the account level.
Why: New idiots are invented daily.

