### PR TITLE
Update ec2-policies with new instance families (2026-04-13)

### DIFF
--- a/catalog/ec2-policies.yaml
+++ b/catalog/ec2-policies.yaml
@@ -40,7 +40,7 @@
     - test: "StringNotLike"
       variable: "ec2:InstanceType"
       values:
-        # updated 2025-02-14
+        # updated 2026-04-13 from us-east-1, us-east-2, us-west-2, eu-west-1
         - a1.*
         - c5.*
         - c5a.*
@@ -60,7 +60,14 @@
         - c7gn.*
         - c7i-flex.*
         - c7i.*
+        - c8a.*
         - c8g.*
+        - c8gb.*
+        - c8gd.*
+        - c8gn.*
+        - c8i.*
+        - c8i-flex.*
+        - c8id.*
         - d3.*
         - d3en.*
         - dl1.*
@@ -72,16 +79,22 @@
         - g5g.*
         - g6.*
         - g6e.*
+        - g6f.*
+        - g7e.*
         - gr6.*
+        - gr6f.*
         - hpc6a.*
         - hpc6id.*
         - hpc7a.*
         - hpc7g.*
+        - hpc8a.*
         - i3en.*
         - i4g.*
         - i4i.*
+        - i7i.*
         - i7ie.*
         - i8g.*
+        - i8ge.*
         - im4gn.*
         - inf1.*
         - inf2.*
@@ -105,12 +118,23 @@
         - m7gd.*
         - m7i-flex.*
         - m7i.*
+        - m8a.*
+        - m8azn.*
         - m8g.*
+        - m8gb.*
+        - m8gd.*
+        - m8gn.*
+        - m8i.*
+        - m8i-flex.*
+        - m8id.*
         - p3dn.*
         - p4d.*
+        - p4de.*
         - p5.*
         - p5e.*
         - p5en.*
+        - p6-b200.*
+        - p6-b300.*
         - r5.*
         - r5a.*
         - r5ad.*
@@ -130,7 +154,14 @@
         - r7gd.*
         - r7i.*
         - r7iz.*
+        - r8a.*
         - r8g.*
+        - r8gb.*
+        - r8gd.*
+        - r8gn.*
+        - r8i.*
+        - r8i-flex.*
+        - r8id.*
         - t3.*
         - t3a.*
         - t4g.*
@@ -154,7 +185,9 @@
         - x2idn.*
         - x2iedn.*
         - x2iezn.*
+        - x8aedz.*
         - x8g.*
+        - x8i.*
         - z1d.*
 
   resources:
@@ -190,7 +223,7 @@
     - test: "StringNotLike"
       variable: "ec2:InstanceType"
       values:
-        # updated 2025-02-14
+        # updated 2026-04-13 from us-east-1, us-east-2, us-west-2, eu-west-1
         - c5a.*
         - c5ad.*
         - c5n.*
@@ -205,7 +238,14 @@
         - c7gn.*
         - c7i-flex.*
         - c7i.*
+        - c8a.*
         - c8g.*
+        - c8gb.*
+        - c8gd.*
+        - c8gn.*
+        - c8i.*
+        - c8i-flex.*
+        - c8id.*
         - d3.*
         - d3en.*
         - dl1.*
@@ -216,16 +256,22 @@
         - g5.*
         - g6.*
         - g6e.*
+        - g6f.*
+        - g7e.*
         - gr6.*
+        - gr6f.*
         - hpc6a.*
         - hpc6id.*
         - hpc7a.*
         - hpc7g.*
+        - hpc8a.*
         - i3en.*
         - i4g.*
         - i4i.*
+        - i7i.*
         - i7ie.*
         - i8g.*
+        - i8ge.*
         - im4gn.*
         - inf1.*
         - inf2.*
@@ -243,12 +289,25 @@
         - m7gd.*
         - m7i-flex.*
         - m7i.*
+        - m8a.*
+        - m8azn.*
         - m8g.*
+        - m8gb.*
+        - m8gd.*
+        - m8gn.*
+        - m8i.*
+        - m8i-flex.*
+        - m8id.*
+        - mac-m4.*
+        - mac-m4pro.*
         - p3dn.*
         - p4d.*
+        - p4de.*
         - p5.*
         - p5e.*
         - p5en.*
+        - p6-b200.*
+        - p6-b300.*
         - r5dn.*
         - r5n.*
         - r6a.*
@@ -261,7 +320,14 @@
         - r7gd.*
         - r7i.*
         - r7iz.*
+        - r8a.*
         - r8g.*
+        - r8gb.*
+        - r8gd.*
+        - r8gn.*
+        - r8i.*
+        - r8i-flex.*
+        - r8id.*
         - trn1.*
         - trn1n.*
         - trn2.*
@@ -281,7 +347,9 @@
         - x2idn.*
         - x2iedn.*
         - x2iezn.*
+        - x8aedz.*
         - x8g.*
+        - x8i.*
 
   resources:
     - "arn:aws:ec2:*:*:instance/*"


### PR DESCRIPTION
## What

Update both `DenyEC2NonNitroInstances` and `DenyEC2InstancesWithoutEncryptionInTransit` SCPs with instance families added since the last update (2025-02-14).

## Why

35 new instance families have been released by AWS since the last update, including 8th generation compute (c8i, c8a), general purpose (m8i, m8a), and memory (r8i, r8a) families. Without this update, the SCPs block these newer instance types.

## How

Generated by running the documented CLI commands across `us-east-1`, `us-east-2`, `us-west-2`, and `eu-west-1` regions, then deduplicating:

```bash
# Nitro
for region in us-east-1 us-east-2 us-west-2 eu-west-1; do
  aws --region $region ec2 describe-instance-types \
    --filters Name=hypervisor,Values=nitro \
    --query "InstanceTypes[*].[InstanceType]" --output text
done | cut -f1 -d. | sort -u

# Encryption in transit
for region in us-east-1 us-east-2 us-west-2 eu-west-1; do
  aws --region $region ec2 describe-instance-types \
    --filters Name=network-info.encryption-in-transit-supported,Values=true \
    --query "InstanceTypes[*].[InstanceType]" --output text
done | cut -f1 -d. | sort -u
```

All original families are preserved; this is an **additive-only change**.

## New families added

| Category | Families |
|----------|----------|
| Compute | `c8a`, `c8gb`, `c8gd`, `c8gn`, `c8i`, `c8i-flex`, `c8id` |
| General purpose | `m8a`, `m8azn`, `m8gb`, `m8gd`, `m8gn`, `m8i`, `m8i-flex`, `m8id` |
| Memory | `r8a`, `r8gb`, `r8gd`, `r8gn`, `r8i`, `r8i-flex`, `r8id` |
| Accelerated | `g6f`, `g7e`, `gr6f`, `p4de`, `p6-b200`, `p6-b300` |
| HPC | `hpc8a` |
| Storage | `i7i`, `i8ge` |
| Other | `mac-m4`, `mac-m4pro`, `x8aedz`, `x8i` |