### PR TITLE
feat: support NotResource in SCP statements

### DIFF
--- a/catalog/bedrock-policies.yaml
+++ b/catalog/bedrock-policies.yaml
@@ -1,0 +1,27 @@
+# Amazon Bedrock service control policies.
+
+# Requires that foundation models be invoked through an inference profile rather
+# than directly by model ID, which is how cross-Region routing and the
+# associated Region guardrails are enforced. The `bedrock:InferenceProfileArn`
+# condition key is absent (Null) when a model is invoked directly.
+#
+# Speech-to-speech models (e.g. Amazon Nova Sonic) are exempted via
+# `not_resources` because they are only reachable through the bidirectional
+# streaming API, which references models directly by ID and does not support
+# inference profiles. That API authorizes as `bedrock:InvokeModel`, and Bedrock
+# exposes no condition key identifying the requested model, so excluding the
+# model ARN is the only way to express the exception.
+# https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithBidirectionalStream.html
+- sid: "DenyDirectFoundationModelAccessExceptBidirectionalStreamModels"
+  effect: "Deny"
+  actions:
+    - "bedrock:InvokeModel"
+    - "bedrock:InvokeModelWithResponseStream"
+  not_resources:
+    - "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-2-sonic-v1:0"
+    - "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-2-sonic-v1:0"
+  condition:
+    - test: "Null"
+      variable: "bedrock:InferenceProfileArn"
+      values:
+        - true

--- a/main.tf
+++ b/main.tf
@@ -16,11 +16,12 @@ data "aws_iam_policy_document" "this" {
   for_each = local.service_control_policy_statements_map
 
   statement {
-    sid         = each.value.sid
-    effect      = each.value.effect
-    actions     = try(each.value.actions, null)
-    not_actions = try(each.value.not_actions, null)
-    resources   = each.value.resources
+    sid           = each.value.sid
+    effect        = each.value.effect
+    actions       = try(each.value.actions, null)
+    not_actions   = try(each.value.not_actions, null)
+    resources     = try(each.value.resources, null)
+    not_resources = try(each.value.not_resources, null)
 
     dynamic "condition" {
       for_each = try(each.value.condition, null) != null ? each.value.condition : []


### PR DESCRIPTION
## what

- Add `not_resources` passthrough to the `aws_iam_policy_document` statement so SCP statements can render a `NotResource` element
- Make `resources` optional (`try(..., null)`) so a statement can specify either `resources` or `not_resources`
- Add a `catalog/bedrock-policies.yaml` entry demonstrating the feature

## why

`NotResource` is currently impossible to express with this module — `resources` is required and `not_resources` isn't passed through. That blocks any deny statement that needs to carve out specific resources when the service offers no condition key to distinguish them.

The motivating case is Amazon Bedrock. A common org guardrail denies `bedrock:InvokeModel` / `bedrock:InvokeModelWithResponseStream` on `foundation-model/*` unless the request carries `bedrock:InferenceProfileArn`, which forces cross-Region inference profile usage and the Region controls built on top of it.

Speech-to-speech models (Amazon Nova Sonic) can't satisfy that guardrail:

- They're only reachable through `InvokeModelWithBidirectionalStream`, which references models **directly by model ID** and does not support inference profiles.
- That API [authorizes as `bedrock:InvokeModel`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModelWithBidirectionalStream.html) — it is not a distinct IAM action, so the action can't be used to scope the exception.
- Bedrock exposes no condition key identifying the requested model, so a `Condition` can't scope it either.

That leaves excluding the model ARN via `NotResource` as the only way to write the exception. This shape was recommended by AWS Support, following the [SCP resource syntax docs](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_syntax.html#scp-syntax-resource).

## backwards compatibility

Additive. Every existing statement in `catalog/` specifies `resources`, so making it optional changes no current output — verified by rendering `catalog/iam-policies.yaml` before and after (identical `Resource`, no stray `NotResource` key).

## test

The Terratest suite walks `catalog/*.yaml` and applies each file, so the new catalog entry is covered by the existing `TestExamplesComplete`.

Rendered output of the new catalog entry:

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "DenyDirectFoundationModelAccessExceptBidirectionalStreamModels",
      "Effect": "Deny",
      "Action": [
        "bedrock:InvokeModelWithResponseStream",
        "bedrock:InvokeModel"
      ],
      "NotResource": [
        "arn:aws:bedrock:us-west-2::foundation-model/amazon.nova-2-sonic-v1:0",
        "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-2-sonic-v1:0"
      ],
      "Condition": {
        "Null": {
          "bedrock:InferenceProfileArn": "true"
        }
      }
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)